### PR TITLE
Bump appcompat from 1.1.0 to 1.3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.1.0'
 
     def appCenterSdkVersion = '2.5.1'


### PR DESCRIPTION
Bumps appcompat from 1.1.0 to 1.3.1.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>